### PR TITLE
Adding the ability to passthru Docker env settings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,5 @@
+Unreleased
+- Adding passthru for Docker env
+
 Version 1.0.0
 - Initial public release.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ rancher::node { 'example_node':
 }
 ```
 
+To add a Docker Node on the Management server
+
+```puppet
+rancher::node { 'manager_node':
+  management         => '10.0.1.2',
+  registration_token => '5074AF5E431560691B8F1457978400000:UZRKUYcESSHKpOTERoOPPor7QY',
+  docker_env         => ["CATTLE_AGENT_IP=${::ipaddress}"]
+}
+```
+
 ## Requirements
 
 We require the following Puppet modules.

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -3,6 +3,7 @@ class rancher::node (
   $management,
   $registration_token,
   $rancher_master_port = 8080,
+  $docker_env = []
 ) {
   validate_string($management)
   validate_string($registration_token)
@@ -21,5 +22,6 @@ class rancher::node (
       '/var/lib/rancher:/var/lib/rancher'
     ],
     require    => Docker::Image['rancher/agent'],
+    env        => $docker_env
   }
 }


### PR DESCRIPTION
Per Rancher's own documentation:

http://docs.rancher.com/rancher/latest/en/hosts/custom/#adding-hosts-to-the-same-machine-as-rancher-server

To add a node on the same host as the rancher server, the IP of the public (non-docker) interface needs to be specified. This pull request adds the ability to pass that environment setting through to Docker.

I also tried to update the README with this change, but you might want to polish that up if it isn't clear.
