### PR TITLE
Feature don't delete server

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 Unreleased
+- Can manage Docker cleanup of volumes and container
 - Adding passthru for Docker env
 
 Version 1.0.0

--- a/manifests/management.pp
+++ b/manifests/management.pp
@@ -11,5 +11,9 @@ class rancher::management(
     image   => 'rancher/server',
     ports   => [ "${rancher_manager_port}:8080" ],
     require => Docker::Image['rancher/server'],
+    remove_container_on_start => false,
+    remove_volume_on_start    => false,
+    remove_container_on_stop  => false,
+    remove_volume_on_stop     => false,
   }
 }

--- a/manifests/management.pp
+++ b/manifests/management.pp
@@ -1,6 +1,8 @@
 # Management Server.
 class rancher::management(
-  $rancher_manager_port = '8080',
+  $rancher_manager_port     = '8080',
+  $docker_cleanup_container = true,
+  $docker_cleanup_volume    = false
 ){
   require docker
 
@@ -8,12 +10,12 @@ class rancher::management(
   }
 
   docker::run { 'rancher/server':
-    image   => 'rancher/server',
-    ports   => [ "${rancher_manager_port}:8080" ],
-    require => Docker::Image['rancher/server'],
-    remove_container_on_start => false,
-    remove_volume_on_start    => false,
-    remove_container_on_stop  => false,
-    remove_volume_on_stop     => false,
+    image                     => 'rancher/server',
+    ports                     => ["${rancher_manager_port}:8080"],
+    require                   => Docker::Image['rancher/server'],
+    remove_container_on_start => $docker_cleanup_container,
+    remove_volume_on_start    => $docker_cleanup_volume,
+    remove_container_on_stop  => $docker_cleanup_container,
+    remove_volume_on_stop     => $docker_cleanup_volume,
   }
 }


### PR DESCRIPTION
Allow choosing to persist the rancher server beyond restarts of the container. Without this option (and setting it to `false`), restarting the host will cause the server (and its MySQL DB) to be recreated. This tends to upset people.

We might consider updating the README if this PR is accepted.